### PR TITLE
Handle empty profile responses

### DIFF
--- a/Commands/AltChecker.cs
+++ b/Commands/AltChecker.cs
@@ -8,6 +8,8 @@ using RestSharp;
 namespace Coflnet.Sky.Commands.MC;
 public class AltChecker
 {
+    private const string StatsBaseUrl = "https://sky.shiiiyu.moe";
+
     /// <summary>
     /// Returns 0-100 probability of the player being an alt
     /// </summary>
@@ -16,14 +18,29 @@ public class AltChecker
     public async Task<int> AltLevel(string uuid)
     {
         var client = new RestClient();
-        var request = new RestRequest($"https://sky.shiiyu.moe/api/v2/coins/{uuid}", Method.Get);
+        var request = new RestRequest($"{StatsBaseUrl}/api/v2/coins/{uuid}", Method.Get);
         var response = await client.ExecuteGetAsync(request);
-        if(response.Content.Contains("no SkyBlock profile"))
+        if (string.IsNullOrWhiteSpace(response.Content))
+            return -1;
+
+        if (response.Content.Contains("no SkyBlock profile", StringComparison.OrdinalIgnoreCase))
         {
-            await client.ExecuteGetAsync(new RestRequest($"https://sky.shiiyu.moe/stats/{uuid}")); // request profile loading
+            await client.ExecuteGetAsync(new RestRequest($"{StatsBaseUrl}/stats/{uuid}")); // request profile loading
             return -1;
         }
-        var result = JsonConvert.DeserializeObject<Response>(response.Content);
+        Response result;
+        try
+        {
+            result = JsonConvert.DeserializeObject<Response>(response.Content);
+        }
+        catch (JsonException)
+        {
+            return -1;
+        }
+
+        if (result?.profiles == null || result.profiles.Count == 0)
+            return -1;
+
         var maxPurse = result.profiles.Values.Max(p => p.purse);
         return (int)Math.Max((20_000_000 - maxPurse) / 1_000_000 * 5, 0);
     }

--- a/Commands/Flipping/ProfileOpenCommand.cs
+++ b/Commands/Flipping/ProfileOpenCommand.cs
@@ -13,7 +13,7 @@ public class ProfileOpenCommand : McCommand
             span.SetTag("name", name);
             socket.ExecuteCommand($"/pv {name}");
             socket.Dialog(db => db.MsgLine($"Opened profile for §6{name}\n{McColorCodes.RESET}If nothing opens you can click this to put the name in chat", "suggest:/pv " + name, "Click to put the name in chat")
-                .LineBreak().MsgLine("Or open on skycrypt", "https://sky.shiiyu.moe/stats/" + name));
+                .LineBreak().MsgLine("Or open on skycrypt", "https://sky.shiiiyu.moe/stats/" + name));
         }, "opening player profile");
     }
 }


### PR DESCRIPTION
Fixes an edge case in alt profile checks.

- return the existing not-ready result for empty or malformed profile responses
- avoid Max() on an empty profile collection
- centralize the external stats base URL used by the profile check