### PR TITLE
Fix #437: too little flips sent

### DIFF
--- a/Commands/Flipping/FlipCommand.cs
+++ b/Commands/Flipping/FlipCommand.cs
@@ -30,6 +30,7 @@ public class FlipCommand : McCommand
                 flipSettings.Value.LastChanged = "flips enabled";
                 await flipSettings.Update();
                 socket.SessionInfo.FlipsEnabled = true;
+                socket.sessionLifesycle.UpdateConnectionTier(await socket.sessionLifesycle.TierManager.GetCurrentCached());
                 WriteCurrentState(socket);
                 socket.Dialog(db => db.CoflCommand<SetCommand>(
                     $"To disable flipper autostart do \n{McColorCodes.AQUA}/cofl set modAutoStartFlipper false",

--- a/Commands/Flipping/FlipCommand.cs
+++ b/Commands/Flipping/FlipCommand.cs
@@ -30,7 +30,6 @@ public class FlipCommand : McCommand
                 flipSettings.Value.LastChanged = "flips enabled";
                 await flipSettings.Update();
                 socket.SessionInfo.FlipsEnabled = true;
-                socket.sessionLifesycle.UpdateConnectionTier(await socket.sessionLifesycle.TierManager.GetCurrentCached());
                 WriteCurrentState(socket);
                 socket.Dialog(db => db.CoflCommand<SetCommand>(
                     $"To disable flipper autostart do \n{McColorCodes.AQUA}/cofl set modAutoStartFlipper false",

--- a/Commands/ModSessionLifesycle.Tests.cs
+++ b/Commands/ModSessionLifesycle.Tests.cs
@@ -149,7 +149,7 @@ public class ModSessionLifesycleTests
     }
 
     [Test]
-    public async Task FlipAlwaysRegistersConnectionForDelivery()
+    public async Task FlipAlwaysDoesNotReplaceExistingRegistration()
     {
         var tierManager = new Mock<IAccountTierManager>();
         tierManager.Setup(manager => manager.GetCurrentCached()).ReturnsAsync(AccountTier.PREMIUM_PLUS);
@@ -161,13 +161,15 @@ public class ModSessionLifesycleTests
             ModSettings = new(),
             AllowedFinders = FinderType.FLIPPER_AND_SNIPERS
         });
+        lifesycle.UpdateConnectionTier(AccountTier.PREMIUM_PLUS);
+        var registration = DiHandler.GetService<FlipperService>().Connections.Single();
         socket.SessionInfo.FlipsEnabled = false;
 
         await new FlipCommand().Execute(socket, "always");
 
         socket.SessionInfo.FlipsEnabled.Should().BeTrue();
-        DiHandler.GetService<FlipperService>().Connections.Should().ContainSingle(
-            connection => ReferenceEquals(connection.Connection, socket));
+        DiHandler.GetService<FlipperService>().Connections.Should().ContainSingle()
+            .Which.Should().BeSameAs(registration);
     }
 
     [TestCase(true)]

--- a/Commands/ModSessionLifesycle.Tests.cs
+++ b/Commands/ModSessionLifesycle.Tests.cs
@@ -148,6 +148,28 @@ public class ModSessionLifesycleTests
         DiHandler.GetService<FlipperService>().Connections.Should().HaveCount(1);
     }
 
+    [Test]
+    public async Task FlipAlwaysRegistersConnectionForDelivery()
+    {
+        var tierManager = new Mock<IAccountTierManager>();
+        tierManager.Setup(manager => manager.GetCurrentCached()).ReturnsAsync(AccountTier.PREMIUM_PLUS);
+        lifesycle.TierManager = tierManager.Object;
+        DiHandler.OverrideService<ITutorialService, TutorialService>(new TutorialService());
+        lifesycle.FlipSettings = SelfUpdatingValue<FlipSettings>.CreateNoUpdate(new FlipSettings
+        {
+            Visibility = new(),
+            ModSettings = new(),
+            AllowedFinders = FinderType.FLIPPER_AND_SNIPERS
+        });
+        socket.SessionInfo.FlipsEnabled = false;
+
+        await new FlipCommand().Execute(socket, "always");
+
+        socket.SessionInfo.FlipsEnabled.Should().BeTrue();
+        DiHandler.GetService<FlipperService>().Connections.Should().ContainSingle(
+            connection => ReferenceEquals(connection.Connection, socket));
+    }
+
     [TestCase(true)]
     [TestCase(false)]
     public async Task PremiumTierFilterUpgrades(bool replace)


### PR DESCRIPTION
Companion regression for #437. The root cause is in the shared flip distributor and is fixed by [Coflnet/SkyBackendForFrontend#122](https://github.com/Coflnet/SkyBackendForFrontend/pull/122).

The original revision re-registered `/cofl flip always` in `FlipCommand`. That workaround was removed: it could replace an already-correct tier registration and reproduce the stale-close ownership race instead of fixing it.

This PR now only verifies the SkyModCommands contract: `/cofl flip always` enables flips without replacing the socket's existing tier registration. The persistent settings and normal tier-registration paths are unchanged.

Verification:

- patched container suite: 262/262 passed;
- the reviewed workaround revision fails the new wrapper-identity assertion;
- final container build passed;
- separate-session review: approved.

Merge/review the owning-library fix in SkyBackendForFrontend#122 first. This PR can then be considered as companion coverage; it does not contain the root production fix itself.

This PR requires human review and merge.
