### PR TITLE
Fix #441: config loading failed

### DIFF
--- a/Commands/SessionFilterState.Tests.cs
+++ b/Commands/SessionFilterState.Tests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Coflnet.Sky.Commands.Shared;
+using Coflnet.Sky.ModCommands.Services;
+using Coflnet.Sky.Settings.Client.Api;
+using Coflnet.Sky.Settings.Client.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Coflnet.Sky.Commands.MC;
+
+public class SessionFilterStateTests
+{
+    [Test]
+    [NonParallelizable]
+    public void SubToConfigChangesUsesSessionUserIdWhenAccountInfoIsMissing()
+    {
+        const string userId = "42";
+        const string ownerId = "17";
+        const string configName = "test";
+        var config = CreateConfig(ownerId, configName);
+        ConfigureSettingsService(ownerId, configName, config);
+        var (socket, lifecycle) = CreateLifecycle(userId, ownerId, configName, config.Version);
+        socket.AddService((ConfigStatsService)RuntimeHelpers.GetUninitializedObject(typeof(ConfigStatsService)));
+
+        Assert.DoesNotThrowAsync(async () => await lifecycle.FilterState.SubToConfigChanges());
+    }
+
+    private static ConfigContainer CreateConfig(string ownerId, string configName)
+    {
+        return new ConfigContainer
+        {
+            Name = configName,
+            OwnerId = ownerId,
+            Version = 3,
+            Settings = new FlipSettings
+            {
+                BlackList = [],
+                WhiteList = []
+            }
+        };
+    }
+
+    private static void ConfigureSettingsService(string ownerId, string configName, ConfigContainer config)
+    {
+        var settingsApi = new Mock<ISettingsApi>();
+        settingsApi
+            .Setup(api => api.GetSettingWithHttpInfoAsync(
+                ownerId,
+                SellConfigCommand.GetKeyFromname(configName),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<string>(HttpStatusCode.OK, JsonConvert.SerializeObject(config)));
+        var configuration = new Mock<IConfiguration>();
+        var settingsService = new SettingsService(configuration.Object, NullLogger<SettingsService>.Instance, settingsApi.Object);
+        DiHandler.OverrideService<SettingsService, SettingsService>(settingsService);
+    }
+
+    private static (TestSocket socket, ModSessionLifesycle lifecycle) CreateLifecycle(
+        string userId,
+        string ownerId,
+        string configName,
+        int configVersion)
+    {
+        var socket = new TestSocket();
+        var lifecycle = new ModSessionLifesycle(socket)
+        {
+            UserId = SelfUpdatingValue<string>.CreateNoUpdate(userId),
+            AccountInfo = SelfUpdatingValue<AccountInfo>.CreateNoUpdate((AccountInfo)null),
+            AccountSettings = SelfUpdatingValue<AccountSettings>.CreateNoUpdate(new AccountSettings
+            {
+                LoadedConfig = new OwnedConfigs.OwnedConfig
+                {
+                    Name = configName,
+                    OwnerId = ownerId,
+                    Version = configVersion
+                }
+            }),
+            FlipSettings = SelfUpdatingValue<FlipSettings>.CreateNoUpdate(new FlipSettings
+            {
+                BlackList = [],
+                WhiteList = []
+            }),
+            TierManager = Mock.Of<IAccountTierManager>(manager => manager.IsLicense == false)
+        };
+        socket.SetLifecycle(lifecycle);
+        return (socket, lifecycle);
+    }
+
+    private sealed class TestSocket : MinecraftSocket
+    {
+        private readonly Dictionary<Type, object> services = new();
+
+        public override bool IsClosed => false;
+
+        public override Activity CreateActivity(string name, Activity parent = null)
+        {
+            return null;
+        }
+
+        public void SetLifecycle(ModSessionLifesycle lifecycle)
+        {
+            sessionLifesycle = lifecycle;
+        }
+
+        public void AddService<T>(T service) where T : class
+        {
+            services[typeof(T)] = service;
+        }
+
+        public override T GetService<T>()
+        {
+            return services.TryGetValue(typeof(T), out var service)
+                ? (T)service
+                : Mock.Of<T>();
+        }
+    }
+}

--- a/Commands/SessionFilterState.cs
+++ b/Commands/SessionFilterState.cs
@@ -80,7 +80,7 @@ public class SessionFilterState : IDisposable
             loadedConfigMetadata.OwnerId,
             loadedConfigMetadata.Name,
             lifesycle.SessionInfo.McUuid,
-            lifesycle.AccountInfo.Value.UserId,
+            lifesycle.AccountInfo?.Value?.UserId ?? socket.UserId,
             loadedConfigMetadata.Version
         );
 


### PR DESCRIPTION
Automated patch for #441 from task `task_enzuos4xer7n77jhrgwq`.

Base branch: `main`
Base commit: `68aa16ce4929f7adfbf350546b23bcfa0a9165ce`

Review: separate codex session recorded.

> WARNING: review uses a separate session of the same provider; it is not an independent-provider review

Tests:
- [x] `container_build` — sha256:a0170a335e47768ba4b14dadae4cdc748925b618f9f8472fbe52621754ceec33
- [x] `regression_base_fail_patch_pass` — trusted-harness exact command, isolated checkout servers, and reviewed test overlays: overlay_derivation=applied:1 sibling_setup_exit=0 overlay_setup_exit=0 overlay_review_digest=unavailable overlay_receipt_sha256=unavailable base_setup_exit=0 base_setup_log_sha256=unavailable server_isolation_exit=0 base_exit=1 base_log_sha256=455f432599f0298f8820df8563678ca70d4ae0073d184520bb793fa444a46f8b patched_exit=0 patched_log_sha256=fbed76f077f4cf2c2a94089aab7a71cf2e9e9140a49f64e7c04c70bf3cea90be

---

Fixed config loading when account details are temporarily absent after load. Config statistics now fall back to the authenticated socket user ID instead of throwing.

- Added focused regression coverage in [SessionFilterState.Tests.cs](/workspace/Commands/SessionFilterState.Tests.cs:24).
- Base: regression fails with `NullReferenceException`.
- Patch: regression passes.
- Required `docker build --pull --tag coflnet-sky-mod-commands-test .` passes.
- Authentication, payments, permissions, tracing, and player-data scope remain unchanged.

Production trace `30209005c3242c7db13a22889dd49094` and its bounded log lookup both returned Jaeger `ServiceUnavailable`, so exact production stack verification was unavailable. The screenshot nevertheless confirms the error occurs after config loading, matching the regression’s post-load path.

---

The reviewer also noted the following, which this patch is not responsible for and did not change:

- Exact production causality remains unverified because the referenced Jaeger trace was unavailable, so the diagnosis relies on the bounded screenshot and repository-only regression.

This PR cannot be merged or approved by the automation identity; human review is required.
